### PR TITLE
User Fixes

### DIFF
--- a/components/shared/RightSidebar.tsx
+++ b/components/shared/RightSidebar.tsx
@@ -29,7 +29,7 @@ function RightSidebar() {
       <div className="flex flex-1 flex-col justify-start">
         <h3 className="text-heading4-small text-slate-500">Recommended Users to connect</h3>
         {recommendedUsers.map((user) => (
-          <div>
+          <div className="pb-3">
             <UserCard
               key={user.id}
               id={user.id}

--- a/components/shared/RightSidebar.tsx
+++ b/components/shared/RightSidebar.tsx
@@ -13,7 +13,7 @@ import { currentUser } from "@clerk/nextjs";
 // };
 
 function RightSidebar() {
-  const [recommendedUsers, setRecommendedUsers] = useState([]);
+  const [recommendedUsers, setRecommendedUsers] = useState<InstanceType<typeof User>[]>([]);
 
   useEffect(() => {
     const fetchUsers = async () => {


### PR DESCRIPTION
 The buttons that say “Connect” have no space with other profile sections. Fixing this to allow for space by adding a [Tailwind](https://tailwindcss.com/) className. 

Fixing a type error: TypeScript was inferring the type of recommendedUsers as never[] because we didn't specify a type when we initialized the state.
